### PR TITLE
Update README.md for new dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ the entries to a designated [XMPP Pubsub Node](http://xmpp.org/extensions/xep-00
 
 ## Requirements
 
-* Python
+* Python >= 3.5
 * GIT Core
 * PIP
 * feedparser
 * jsonpickle
-* sleekxmpp
+* slixmpp
 * screen
 
-AtomToPubsub is built using Python 2.6 and use the librairies
+AtomToPubsub is built using Python 3.5 and uses the libraries
 
 ## Installation
 


### PR DESCRIPTION
The README is outdated as Python >= 3.5 is needed.

Regarding the installation instructions for [Ubuntu/Debian](Debian-Installation) this also means that at least Debian 9 (stretch) is needed.