### PR TITLE
This patch fixes a bug with some atom feeds in Movim. 

### DIFF
--- a/publishx.py
+++ b/publishx.py
@@ -71,7 +71,8 @@ class Publishx(slixmpp.ClientXMPP):
         iq['pubsub']['publish']['node'] = node
 
         item = pubsub.Item()
-        item['id'] = entry.id
+        # character / is causing a bug in movim. replacing : and , with - in id. It provides nicer urls.
+        item['id'] = str(entry.id).replace('/', '-').replace(':', '-').replace(',', '-')
 
         ent = ET.Element("entry")
         ent.set('xmlns', NS_ATOM)
@@ -106,7 +107,7 @@ class Publishx(slixmpp.ClientXMPP):
 
         iq['pubsub']['publish'].append(item)
 
-        task = iq.send(timeout=5)
+        task = iq.send(timeout=20)
         try:
             await task
         except IqError:

--- a/publishx.py
+++ b/publishx.py
@@ -4,6 +4,7 @@ import slixmpp
 from slixmpp.xmlstream import ET
 import slixmpp.plugins.xep_0060.stanza.pubsub as pubsub
 from slixmpp.exceptions import IqError
+import re
 
 NS_ATOM = 'http://www.w3.org/2005/Atom'
 NS_JABBER_DATA = 'jabber:x:data'
@@ -72,7 +73,8 @@ class Publishx(slixmpp.ClientXMPP):
 
         item = pubsub.Item()
         # character / is causing a bug in movim. replacing : and , with - in id. It provides nicer urls.
-        item['id'] = str(entry.id).replace('/', '-').replace(':', '-').replace(',', '-')
+        rex = re.compile(r'[:,\/]')
+        item['id'] = rex.sub('-', str(entry.id))
 
         ent = ET.Element("entry")
         ent.set('xmlns', NS_ATOM)


### PR DESCRIPTION
When the id contains a "/", it cannot be displayed in Movim.

This patch replace "/" in the id with '-' even if "/" are valid characters in the pubsub norm (to the best of my knowledge).

This patch also replace "," and ":" even if those did not cause any arm with Movim. In my personnal opinion, "-" are easier to read in url.