### PR TITLE
Various fixes

### DIFF
--- a/atomtopubsub.py
+++ b/atomtopubsub.py
@@ -100,8 +100,7 @@ def main():
 
     xmpp = Publishx(config)
     xmpp.connect()
-    xmpp.process(timeout=2)
-    asyncio.ensure_future(parse(load(), xmpp))
+    xmpp.add_event_handler('session_start', lambda _: asyncio.ensure_future(parse(load(), xmpp)))
     xmpp.process()
 
 

--- a/atomtopubsub.py
+++ b/atomtopubsub.py
@@ -74,7 +74,7 @@ async def parse(parsed, xmpp):
         minutes = float(config.refresh_time) / len(config.feeds)
         print(colored('Parsing next feed in %.2f minutes' % minutes, 'cyan'))
         await asyncio.sleep(minutes * 60)
-        asyncio.ensure_future(parse(parsed, xmpp))
+    asyncio.ensure_future(parse(parsed, xmpp))
 
 
 def load():

--- a/atomtopubsub.py
+++ b/atomtopubsub.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import asyncio
 import feedparser

--- a/publishx.py
+++ b/publishx.py
@@ -18,13 +18,7 @@ class Publishx(slixmpp.ClientXMPP):
         resource = config.resource
 
         slixmpp.ClientXMPP.__init__(self, fulljid, secret)
-
-        self.add_event_handler("session_start", self.start)
         self.register_plugin('xep_0060')
-
-    def start(self, event):
-        # self.send_presence(ptype='invisible', pstatus='AtomToPubsub')
-        self.get_roster()
 
     async def create(self, server, node, feed):
         title = description = logo = ''


### PR DESCRIPTION
- Shebang is now properly set to python3
- Fix bug where `parse` would be enqueued after each feed is parsed
- Fix bug where `parse` would be called before the XMPP stream is ready
- Remove unused roster call