### PR TITLE
Correct to Atom 0.3

### DIFF
--- a/publishx.py
+++ b/publishx.py
@@ -82,7 +82,7 @@ class Publishx(slixmpp.ClientXMPP):
         updated = ET.SubElement(ent, "updated")
         updated.text = entry.updated
 #Content
-        if version == 'atom3':
+        if version == 'atom03':
 
             if hasattr(entry.content[0], 'type'):
                 content = ET.SubElement(ent, "content")


### PR DESCRIPTION
There is no `atom3` in feedparser. See https://feedparser.readthedocs.io/en/latest/reference-version.html